### PR TITLE
Add support for multiple Instagram accounts

### DIFF
--- a/MMM-Instagram.js
+++ b/MMM-Instagram.js
@@ -10,6 +10,7 @@
 Module.register('MMM-Instagram', {
 
     defaults: {
+        apiUrl: 'https://api.instagram.com/v1/users/self/media/recent',
         format: 'json',
         lang: 'en-us',
         id: '',
@@ -22,19 +23,12 @@ Module.register('MMM-Instagram', {
         instaMaxHeight: '100%',
         loadingText: 'Loading...'
     },
-    
+
     // Define required scripts
     getScripts: function() {
         return ["moment.js"];
     },
-    
-    /*
-    // Define required translations
-    getTranslations: function() {
-        return false;
-    },
-    */
-    
+
     // Define start sequence
     start: function() {
         Log.info('Starting module: ' + this.name);
@@ -42,21 +36,10 @@ Module.register('MMM-Instagram', {
         this.loaded = false;
         this.images = {};
         this.activeItem = 0;
-        this.url = 'https://api.instagram.com/v1/users/self/media/recent' + this.getParams();
-        this.grabPhotos();
+        this.apiUrls = this.getApiUrls();
+        this.sendSocketNotification("INSTAGRAM_GET", this.apiUrls);
     },
 
-    grabPhotos: function() {
-        // the notifications are not working for some reason... so we won't do anything asynchronously
-        // we will just make the call to the method to get the object with photo links....
-        //Log.info('sending socket notification: INSTAGRAM_GET and URL: ' + this.url);
-        this.sendSocketNotification("INSTAGRAM_GET", this.url);
-        
-        // this may not be needed... need to think about it.
-        //setTimeout(this.grabPhotos, this.config.interval, this);
-    },
-    
-    
     getStyles: function() {
         return ['instagram.css', 'font-awesome.css'];
     },
@@ -70,28 +53,23 @@ Module.register('MMM-Instagram', {
             wrapper.innerHTML = this.config.loadingText;
             return wrapper;
         }
-        
+
         // set the first item in the list...
         if (this.activeItem >= this.images.photo.length) {
             this.activeItem = 0;
         }
-        
-        var tempimage = this.images.photo[this.activeItem];
-        
-        // image       
-	//imageLink.innerHTML = "<img src='https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png'>";
-        
+
+        var tempImage = this.images.photo[this.activeItem];
 
         var imageWrapper = document.createElement("img");
-	    imageWrapper.src = tempimage.photolink;
-	    imageWrapper.id = "MMM-Instagram-image";
-	    imageWrapper.style.maxWidth = this.config.instaMaxWidth;
-	    imageWrapper.style.maxHeight = this.config.instaMaxHeight;
-	    imageDisplay.appendChild(imageWrapper);
-        
+  	    imageWrapper.src = tempImage.photolink;
+  	    imageWrapper.id = "MMM-Instagram-image";
+  	    imageWrapper.style.maxWidth = this.config.instaMaxWidth;
+  	    imageWrapper.style.maxHeight = this.config.instaMaxHeight;
+  	    imageDisplay.appendChild(imageWrapper);
 
-	wrapper.appendChild(imageDisplay);
-       
+	      wrapper.appendChild(imageDisplay);
+
         return wrapper;
     },
 
@@ -112,16 +90,22 @@ Module.register('MMM-Instagram', {
     },
 
     /*
-     * getParams()
-     * returns the query string required for the request to flickr to get the 
-     * photo stream of the user requested
+     * getApiUrls()
+     * returns the query strings required for the request to instagram to get the
+     * photo streams of the users requested
      */
-    getParams: function() {
-        var params = '?';
-        params += 'count=' + this.config.count;
-        params += '&min_timestamp=' + this.config.min_timestamp;
-        params += '&access_token=' + this.config.access_token;
-        return params;
+    getApiUrls: function() {
+        var tokens = this.config.access_token || this.config.access_tokens; //default for backwards compatibility
+        if(!Array.isArray(tokens)){
+          tokens = [tokens];
+        }
+        return tokens.map(token => {
+          var url = this.config.apiUrl + '?';
+          url += 'count=' + this.config.count;
+          url += '&min_timestamp=' + this.config.min_timestamp;
+          url += '&access_token=' + token;
+          return url;
+        });
     },
 
     // override socketNotificationReceived
@@ -129,17 +113,14 @@ Module.register('MMM-Instagram', {
         //Log.info('socketNotificationReceived: ' + notification);
         if (notification === 'INSTAGRAM_IMAGE_LIST')
         {
-            //Log.info('received INSTAGRAM_IMAGE_LIST');
             this.images = payload;
-            
-            //Log.info("count: " +  this.images.photo.length);
-            
+
             // we want to update the dom the first time and then schedule next updates
             if (!this.loaded) {
-            this.updateDom(1000);
-                this.scheduleUpdateInterval();
+              this.updateDom(1000);
+              this.scheduleUpdateInterval();
             }
-            
+
             this.loaded = true;
         }
     }

--- a/MMM-Instagram.js
+++ b/MMM-Instagram.js
@@ -9,131 +9,158 @@
 
 Module.register('MMM-Instagram', {
 
-    defaults: {
-        apiUrl: 'https://api.instagram.com/v1/users/self/media/recent',
-        format: 'json',
-        lang: 'en-us',
-        id: '',
-        animationSpeed: 1000,
-        updateInterval: 60000, // 10 minutes
-        access_token: '',
-        count: 200,
-        randomize: false,
-        min_timestamp: 0,
-        instaMaxWidth: '100%',
-        instaMaxHeight: '100%',
-        loadingText: 'Loading...'
-    },
+	defaults: {
+	    apiUrl: "https://graph.instagram.com/me/media",
+	    format: "json",
+	    lang: "en-us",
+	    id: "",
+	    animationSpeed: 1000,
+	    updateInterval: 60000, // 10 minutes
+	    access_token: "",
+	    count: 200,
+	    randomize: false,
+	    min_timestamp: 0,
+	    instaMaxWidth: "100%",
+	    instaMaxHeight: "100%",
+	    loadingText: "Fetching ..."
+	},
 
-    // Define required scripts
-    getScripts: function() {
-        return ["moment.js"];
-    },
+	// Define required scripts
+	getScripts: function () {
+		return ["moment.js"];
+	},
 
-    // Define start sequence
-    start: function() {
-        Log.info('Starting module: ' + this.name);
-        this.data.classes = 'bright medium';
-        this.loaded = false;
-        this.images = [];
-        this.activeItem = 0;
-        this.apiUrls = this.getApiUrls();
-        this.sendSocketNotification("INSTAGRAM_GET", this.apiUrls);
-    },
+	// Define start sequence
+	start: function () {
+		Log.info("Starting module: " + this.name);
+		this.data.classes = "bright medium";
+		this.loaded = false;
+		this.media = [];
+		this.activeItem = 0;
+		this.apiUrls = this.getApiUrls();
+		this.sendSocketNotification("INSTAGRAM_GET", this.apiUrls);
+	},
 
-    getStyles: function() {
-        return ['instagram.css', 'font-awesome.css'];
-    },
+	getStyles: function () {
+		Log.info("styles");
+		return ["instagram.css", "font-awesome.css"];
+	},
 
-    // Override the dom generator
-    getDom: function() {
-        var wrapper = document.createElement("div");
-        var imageDisplay = document.createElement('div'); //support for config.changeColor
+	// Override the dom generator
+	getDom: function () {
+		var wrapper = document.createElement("div");
+		var mediaDisplay = document.createElement("div"); //support for config.changeColor
 
-        if (!this.loaded) {
-            wrapper.innerHTML = this.config.loadingText;
-            return wrapper;
-        }
+		if (!this.loaded) {
+			wrapper.innerHTML = this.config.loadingText;
+			return wrapper;
+		}
 
-        // set the first item in the list...
-        if (this.activeItem >= this.images.length) {
-            this.activeItem = 0;
-        }
+		// set the first item in the list...
+		if (this.activeItem >= this.media.length) {
+			this.activeItem = 0;
+		}
 
-        var tempImage = this.images[this.activeItem];
+		var mediaItem = this.media[this.activeItem];
+		Log.info("Creating video element for type " + mediaItem.media_type + " for media_url: " + mediaItem.media_url)
 
-        var imageWrapper = document.createElement("img");
-  	    imageWrapper.src = tempImage.photolink;
-  	    imageWrapper.id = "MMM-Instagram-image";
-  	    imageWrapper.style.maxWidth = this.config.instaMaxWidth;
-  	    imageWrapper.style.maxHeight = this.config.instaMaxHeight;
-  	    imageDisplay.appendChild(imageWrapper);
+		if (mediaItem.media_type === "IMAGE" || mediaItem.media_type === "CAROUSEL_ALBUM") {
+			var imageWrapper = this.getImageWrapper(mediaItem);
+			mediaDisplay.appendChild(imageWrapper);
+		} else if (mediaItem.media_type === "VIDEO") {
+			var videoWrapper = this.getVideoWrapper(mediaItem);
+			mediaDisplay.appendChild(videoWrapper);
+		}
+		wrapper.appendChild(mediaDisplay);
+		return wrapper;
+	},
 
-	      wrapper.appendChild(imageDisplay);
+	getImageWrapper: function (image) {
+		Log.info("styles");
+		var img = document.createElement("img");
+		img.src = image.media_url;
+		img.id = "MMM-Instagram-image";
+		img.setAttribute("width", "300");
+		img.style.maxWidth = this.config.instaMaxWidth;
+		img.style.maxHeight = this.config.instaMaxHeight;
+		return img;
+	},
 
-        return wrapper;
-    },
+	getVideoWrapper: function (video) {
+		var videoWrapper = document.createElement("video");
+		videoWrapper.setAttribute("autoplay", "");
+		videoWrapper.setAttribute("muted", "");
+		videoWrapper.setAttribute("loop", "");
+		videoWrapper.setAttribute("width", "300");
+		videoWrapper.style.maxWidth = this.config.instaMaxWidth;
+		videoWrapper.style.maxHeight = this.config.instaMaxHeight;
+		var sourceWrapper = document.createElement("source");
+		sourceWrapper.src = video.media_url;
+		sourceWrapper.id = "MMM-Instagram-image";
+		sourceWrapper.type = "video/mp4"
+		videoWrapper.appendChild(sourceWrapper);
+		return videoWrapper;
+	},
 
-    /* scheduleUpdateInterval()
-     * Schedule visual update.
-     */
-    scheduleUpdateInterval: function() {
-        var self = this;
+	/* scheduleUpdateInterval()
+	 * Schedule visual update.
+	 */
+	scheduleUpdateInterval: function () {
+	    var self = this;
 
-        Log.info("Scheduled update interval set up...");
-        self.updateDom(self.config.animationSpeed);
+	    Log.info("Scheduled update interval set up...");
+	    self.updateDom(self.config.animationSpeed);
 
-        setInterval(function() {
-            Log.info("incrementing the activeItem and refreshing");
-            self.activeItem++;
-            self.updateDom(self.config.animationSpeed);
-        }, this.config.updateInterval);
-    },
+	    setInterval(function () {
+	        Log.info("incrementing the activeItem and refreshing");
+	        self.activeItem++;
+	        self.updateDom(self.config.animationSpeed);
+	    }, this.config.updateInterval);
+	},
 
-    /*
+	/*
      * getApiUrls()
      * returns the query strings required for the request to instagram to get the
      * photo streams of the users requested
      */
-    getApiUrls: function() {
-        var tokens = this.config.access_token || this.config.access_tokens; //default for backwards compatibility
-        if(!Array.isArray(tokens)){
-          tokens = [tokens];
-        }
-        return tokens.map(token => {
-          var url = this.config.apiUrl + '?';
-          url += 'count=' + this.config.count;
-          url += '&min_timestamp=' + this.config.min_timestamp;
-          url += '&access_token=' + token;
-          return url;
-        });
-    },
+	getApiUrls: function() {
+		var tokens = this.config.access_token || this.config.access_tokens; //default for backwards compatibility
+		if(!Array.isArray(tokens)){
+			tokens = [tokens];
+		}
+		return tokens.map(token => {
+			var url = this.config.apiUrl;
+			url += "?fields=caption,media_url,media_type,id";
+			url += "&limit=200";
+			url += "&access_token=" + token;
+			return url;
+		});
+	},
 
-    shuffle: function(array) {
-      for (var i = array.length - 1; i > 0; i--) {
-          var j = Math.floor(Math.random() * (i + 1));
-          var temp = array[i];
-          array[i] = array[j];
-          array[j] = temp;
-      }
-      return array;
-    },
+	shuffle: function (array) {
+	    for (var i = array.length - 1; i > 0; i--) {
+	        var j = Math.floor(Math.random() * (i + 1));
+	        var temp = array[i];
+	        array[i] = array[j];
+	        array[j] = temp;
+	    }
+	    return array;
+	},
+	// override socketNotificationReceived
+	socketNotificationReceived: function (notification, payload) {
+	    //Log.info('socketNotificationReceived: ' + notification);
+	    if (notification === "INSTAGRAM_IMAGE_LIST") {
+	        this.media = this.config.randomize ? this.shuffle(payload) : payload;
 
-    // override socketNotificationReceived
-    socketNotificationReceived: function(notification, payload) {
-        //Log.info('socketNotificationReceived: ' + notification);
-        if (notification === 'INSTAGRAM_IMAGE_LIST')
-        {
-            this.images = this.config.randomize ? this.shuffle(payload) : payload;
+	        // we want to update the dom the first time and then schedule next updates
+	        if (!this.loaded) {
+	            this.updateDom(1000);
+	            this.scheduleUpdateInterval();
+	        }
 
-            // we want to update the dom the first time and then schedule next updates
-            if (!this.loaded) {
-              this.updateDom(1000);
-              this.scheduleUpdateInterval();
-            }
+	        this.loaded = true;
+	    }
+	}
 
-            this.loaded = true;
-        }
-    }
 
 });

--- a/MMM-Instagram.js
+++ b/MMM-Instagram.js
@@ -18,6 +18,7 @@ Module.register('MMM-Instagram', {
         updateInterval: 60000, // 10 minutes
         access_token: '',
         count: 200,
+        randomize: false,
         min_timestamp: 0,
         instaMaxWidth: '100%',
         instaMaxHeight: '100%',
@@ -34,7 +35,7 @@ Module.register('MMM-Instagram', {
         Log.info('Starting module: ' + this.name);
         this.data.classes = 'bright medium';
         this.loaded = false;
-        this.images = {};
+        this.images = [];
         this.activeItem = 0;
         this.apiUrls = this.getApiUrls();
         this.sendSocketNotification("INSTAGRAM_GET", this.apiUrls);
@@ -55,11 +56,11 @@ Module.register('MMM-Instagram', {
         }
 
         // set the first item in the list...
-        if (this.activeItem >= this.images.photo.length) {
+        if (this.activeItem >= this.images.length) {
             this.activeItem = 0;
         }
 
-        var tempImage = this.images.photo[this.activeItem];
+        var tempImage = this.images[this.activeItem];
 
         var imageWrapper = document.createElement("img");
   	    imageWrapper.src = tempImage.photolink;
@@ -108,12 +109,22 @@ Module.register('MMM-Instagram', {
         });
     },
 
+    shuffle: function(array) {
+      for (var i = array.length - 1; i > 0; i--) {
+          var j = Math.floor(Math.random() * (i + 1));
+          var temp = array[i];
+          array[i] = array[j];
+          array[j] = temp;
+      }
+      return array;
+    },
+
     // override socketNotificationReceived
     socketNotificationReceived: function(notification, payload) {
         //Log.info('socketNotificationReceived: ' + notification);
         if (notification === 'INSTAGRAM_IMAGE_LIST')
         {
-            this.images = payload;
+            this.images = this.config.randomize ? this.shuffle(payload) : payload;
 
             // we want to update the dom the first time and then schedule next updates
             if (!this.loaded) {

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The entry in `config.js` can include the following options:
 
 |Option|Description|
 |---|---|
-|`access_token(s)`|Access token(s) which is received from Instagram<br><br>**Type:** `array of strings`<br>At least one value is **REQUIRED**|
+|`access_token(s)`|Access token(s) which is received from Instagram<br><br>**Type:** `string or array of strings`<br>At least one value is **REQUIRED**|
 |`count`|Number of pictures to pull from the feed.<br><br>This value is **REQUIRED**|
 |`min_timestamp`|Set to 0 to pull images from when you created the account.<br><br>This value is **REQUIRED**|
 |`animationSpeed`|How long the fade out and fade in of photos should take.<br><br>This value is **REQUIRED**|

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This a module for the [MagicMirror](https://github.com/MichMich/MagicMirror/tree/develop). It pulls photos from your own or another users Instagram feed (requires API_KEY). The photos are then rotated and animated in the screen.
 
 ## Installation
-1. Navigate into your MagicMirror's `modules` folder and execute `git clone https://github.com/kapsolas/MMM-Instagram.git`. A new folder will appear, navigate into it.
+1. Navigate into your MagicMirror's `modules` folder and execute `git clone https://github.com/O5ten/MMM-Instagram.git`. A new folder will appear, navigate into it.
 2. Execute `npm install` to install the node dependencies.
 
 ## Config
@@ -13,17 +13,18 @@ The entry in `config.js` can include the following options:
             module: 'MMM-Instagram',
             position: 'top_left',
             config: {
-                access_token: '1160247792.b119586.49fa97770ee34deb92e621069c760cee',
+                access_tokens: ['1160247792.b119586.49fa97770ee34deb92e621069c760cee'],
                 count: 200,
                 min_timestamp: 0,
                 animationSpeed: 2500,
                 updateInterval: 12000
-            }
+	    }
+ }
 
 
 |Option|Description|
 |---|---|
-|`access_token`|Access token which is received from Instagram<br><br>**Type:** `string`<br>This value is **REQUIRED**|
+|`access_token(s)`|Access token(s) which is received from Instagram<br><br>**Type:** `array of strings`<br>At least one value is **REQUIRED**|
 |`count`|Number of pictures to pull from the feed.<br><br>This value is **REQUIRED**|
 |`min_timestamp`|Set to 0 to pull images from when you created the account.<br><br>This value is **REQUIRED**|
 |`animationSpeed`|How long the fade out and fade in of photos should take.<br><br>This value is **REQUIRED**|
@@ -37,7 +38,7 @@ Here is an example of an entry in `config.js`
 	module: 'MMM-Instagram',
 	position: 'top_right',
 	config: {
-		access_token: 'API_KEY from instagram',
+		access_tokens: ['API_KEY from instagram'],
 		count: 200,  
 		min_timestamp: 0,
 		animationSpeed: 2500,
@@ -50,9 +51,7 @@ Here is an example of an entry in `config.js`
 
 ## Dependencies
 - [request](https://www.npmjs.com/package/request) (installed via `npm install`)
-
-## Important Notes
-- This is one of my first projects using Node, so feel free to submit pull requests or post on the issues/wiki and I will do my best to improve the project.
+- [request-promise-native](https://www.npmjs.com/package/request-promise-native) (installed via `npm install`)
 
 ## Special Thanks
 - [Michael Teeuw](https://github.com/MichMich) for creating the awesome [MagicMirror2](https://github.com/MichMich/MagicMirror/tree/develop) project that made this module possible.

--- a/node_helper.js
+++ b/node_helper.js
@@ -5,48 +5,49 @@
  * MIT Licensed.
  */
 
- var NodeHelper = require("node_helper");
- var rp = require('request-promise-native');
+var NodeHelper = require("node_helper");
+var rp = require("request-promise-native");
 
- module.exports = NodeHelper.create({
+module.exports = NodeHelper.create({
 
-    start: function() {
-        console.log("Starting node_helper for module [" + this.name + "]");
-    },
+	start: function() {
+		console.log("Starting node_helper for module [" + this.name + "]");
+	},
 
-    socketNotificationReceived: function(notification, apiUrls){
-        if (notification === 'INSTAGRAM_GET') {
-            this.fetchImages(apiUrls);
-        }
-    },
+	socketNotificationReceived: function(notification, apiUrls){
+		if (notification === "INSTAGRAM_GET") {
+			this.fetchImages(apiUrls);
+		}
+	},
 
-    fetchImages: function(apiUrls) {
-      var self = this;
-      var promises = apiUrls.map(url => {
-        return rp({
-          uri: url,
-          method: 'GET',
-          json: true
-        }).then(items => {
-          return items.data.map(item => {
-            return {
-              "type": item.type,
-              "photolink": item.images.low_resolution.url
-            };
-          });
-        }).catch(error => {
-          console.log("Error requesting " + url + ": ", error);
-        });
-      });
-      Promise.all(promises)
-        .then(results => {
-          self.sendSocketNotification('INSTAGRAM_IMAGE_LIST',
-            results.reduce((acc, item) => {
-              return acc.concat(item);
-            }, [])
-          );
-        }).catch(error => {
-          console.log("Error: ", error);
-        });
-    }
- });
+	fetchImages: function(apiUrls) {
+		var self = this;
+		var promises = apiUrls.map(url => {
+			return rp({
+				uri: url,
+				method: "GET",
+				json: true
+			}).then(items => {
+				var media = items.data.map(item => {
+					return {
+						"media_type": item.media_type,
+						"media_url": item.media_url
+					};
+				});
+				return media;
+			}).catch(error => {
+				console.log("Error requesting " + url + ": ", error);
+			});
+		});
+		Promise.all(promises)
+			.then(results => {
+				self.sendSocketNotification("INSTAGRAM_IMAGE_LIST",
+					results.reduce((acc, item) => {
+						return acc.concat(item);
+					}, [])
+				);
+			}).catch(error => {
+				console.log("Error: ", error);
+			});
+	}
+});

--- a/node_helper.js
+++ b/node_helper.js
@@ -6,7 +6,6 @@
  */
 
  var NodeHelper = require("node_helper");
- var request = require('request');
  var rp = require('request-promise-native');
 
  module.exports = NodeHelper.create({
@@ -41,11 +40,11 @@
       });
       Promise.all(promises)
         .then(results => {
-          self.sendSocketNotification('INSTAGRAM_IMAGE_LIST', {
-            photo: results.reduce((acc, item) => {
+          self.sendSocketNotification('INSTAGRAM_IMAGE_LIST',
+            results.reduce((acc, item) => {
               return acc.concat(item);
             }, [])
-          });
+          );
         }).catch(error => {
           console.log("Error: ", error);
         });

--- a/node_helper.js
+++ b/node_helper.js
@@ -7,56 +7,47 @@
 
  var NodeHelper = require("node_helper");
  var request = require('request');
- 
+ var rp = require('request-promise-native');
+
  module.exports = NodeHelper.create({
-    // subclass start method.
+
     start: function() {
         console.log("Starting node_helper for module [" + this.name + "]");
     },
-    
-    // subclass socketNotificationReceived
-    socketNotificationReceived: function(notification, payload){
-        //console.log("=========== notification received: " + notification);
+
+    socketNotificationReceived: function(notification, apiUrls){
         if (notification === 'INSTAGRAM_GET') {
-            this.getImagesFromJSON(payload);
+            this.fetchImages(apiUrls);
         }
     },
-    
-    getImagesFromJSON: function(api_url) {
-        //console.log('============ HERE =================');
-        var self = this;
-        request({url: api_url, method: 'GET'}, function(error, response, body) 
-        {
-            if (!error && response.statusCode == 200) 
-            {
-                // get our images out of the INSTAGRAM JSON response
-                var items = JSON.parse(body).data;
-                
-                // create our model, a dictionary with 
-                var images = {};
-                images.photo = new Array();
-                
-                for (var i in items)
-                {
-                    var type = items[i].type;
-                    var media = items[i].images.low_resolution.url;
-                    
-                    //console.log("type: " + type + "\nmedia: " + media);
-                    
-                    // create a new array for each images object in the dictionary
-                    images.photo.push( {
-                        "type" : type,
-                        "photolink" : media
-                    });
-                }
-                //console.log("count: " + images.photo.length);
-                self.sendSocketNotification('INSTAGRAM_IMAGE_LIST', images);
-                
-            }
-            else
-            {
-                console.log(" Error: " + response.statusCode);
-            }
+
+    fetchImages: function(apiUrls) {
+      var self = this;
+      var promises = apiUrls.map(url => {
+        return rp({
+          uri: url,
+          method: 'GET',
+          json: true
+        }).then(items => {
+          return items.data.map(item => {
+            return {
+              "type": item.type,
+              "photolink": item.images.low_resolution.url
+            };
+          });
+        }).catch(error => {
+          console.log("Error requesting " + url + ": ", error);
+        });
+      });
+      Promise.all(promises)
+        .then(results => {
+          self.sendSocketNotification('INSTAGRAM_IMAGE_LIST', {
+            photo: results.reduce((acc, item) => {
+              return acc.concat(item);
+            }, [])
+          });
+        }).catch(error => {
+          console.log("Error: ", error);
         });
     }
  });

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/SamLewis0602/MMM-Traffic#readme",
   "dependencies": {
-    "request": "latest"
-    }
+    "request": "latest",
+    "request-promise-native": "^1.0.5"
+  }
 }


### PR DESCRIPTION
My wife wanted both our instagram accounts to be shown on our magic mirror, and the module didn't support it, so i added it through request-promises to fire a set of requests against a list of access_tokens. 

- Support for multiple access tokens, still backwards compatible with only having one token as a string
- General cleanup as the project had lots of comments and indentation issues

Based on jeffjoes fork, hence the PR. 